### PR TITLE
Warp PE in PEArray and Update CodeBlock at the beginning the each cycle.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 cmake-build-debug/
+cmake-build-relase/
 .idea/
 build/
 .vscode/

--- a/include/CodeBlock.h
+++ b/include/CodeBlock.h
@@ -47,15 +47,21 @@ public:
         if (empty()) {
             // signal all downstream CodeBlocks
             for (const auto& cb : to_signal) {
-                cb->constraint_cnt--;
+                cb->constraint_delta++;
             }
         }
 
         return inst;
     }
 
+    void update_constraint(){
+        constraint_cnt -= constraint_delta;
+        constraint_delta = 0;
+    }
+
 private:
     int constraint_cnt;
+    int constraint_delta; // update at the entry of the next cycle
     std::vector<std::shared_ptr<Inst>> inst_stream;
     std::set<std::shared_ptr<CodeBlock>> to_signal; // downstream CodeBlocks
 

--- a/include/LocalScheduler.h
+++ b/include/LocalScheduler.h
@@ -10,11 +10,11 @@
 /* In current design, Scheduler is assgined to each PE */
 class LocalScheduler {
 public:
-    void addCodeBlock(const std::shared_ptr<CodeBlock>& CodeBlock) {
+    void addCodeBlock(std::shared_ptr<CodeBlock> code_block) {
         /* This is now a naive implementation for testing
             TODO: Place the four types of instructions in a CodeBlock into their respective instruction queues.
         */
-        waiting_CodeBlocks.insert(CodeBlock);
+        waiting_CodeBlocks.insert(code_block);
     };
 
     std::shared_ptr<Inst> getReadyInstruction() {

--- a/include/PE.h
+++ b/include/PE.h
@@ -8,9 +8,14 @@
 #include "SPM.h"
 class PE {
 public:
-    PE(std::unique_ptr<LocalScheduler> scheduler_ptr, std::shared_ptr<SPM> spm_ptr){
+    /*PE(){
         reg = VectorRegisterFile(2048);
-        scheduler = std::move(scheduler_ptr);
+        scheduler = std::make_unique<LocalScheduler>();
+    };*/
+
+    PE(std::shared_ptr<SPM> spm_ptr= nullptr) {
+        reg = VectorRegisterFile(2048);
+        scheduler = std::make_unique<LocalScheduler>();
         accessable_memory = std::move(spm_ptr);
     }
 
@@ -19,8 +24,14 @@ public:
         inst->execute(reg, accessable_memory);
     }; // perform the operations in the current cycle
 
-    /* Fetch the next instruction from the scheduler
-     * execute the instruction */
+    void add_CodeBlock(std::shared_ptr<CodeBlock> code_block) {
+        scheduler->addCodeBlock(code_block);
+    }
+
+    void set_memory(std::shared_ptr<SPM> spm_ptr) {
+        accessable_memory = std::move(spm_ptr);
+    }
+
     void copy(); // TODO: design a machesim to simulate the copy operation
 
     void display_reg_as_fp32(int idx) {

--- a/include/PEArray.h
+++ b/include/PEArray.h
@@ -1,0 +1,45 @@
+#ifndef PEARRAY_H
+#define PEARRAY_H
+
+#include "common.h"
+#include "LocalScheduler.h"
+#include "PE.h"
+#include "SPM.h"
+
+template <int _num_row, int _num_col, int _memory_size>
+class PEArray {
+    /* The PEArray class manages PEs and On-Chip routers */
+public:
+    PEArray() {
+        // make PE array
+        spm = std::make_shared<SPM>(_memory_size);
+        // attach memory to each PE
+        for (int i = 0; i < _num_row; i++) {
+            for (int j = 0; j < _num_col; j++) {
+                PE_array_2d[i][j].set_memory(spm);
+            }
+        }
+    }
+
+    void execute_cycle(){
+        for (int i = 0; i < _num_row; i++) {
+            for (int j = 0; j < _num_col; j++) {
+                PE_array_2d[i][j].execute_cycle();
+            }
+        } 
+    }
+
+    void add_CodeBlock(int pe_row, int pe_col, std::shared_ptr<CodeBlock> code_block){
+        std::cout<<"add code block to PE["<<pe_row<<"]["<<pe_col<<"]\n";
+        assert(pe_row < _num_row && pe_col < _num_col);
+        PE_array_2d[pe_row][pe_col].add_CodeBlock(code_block);
+    }
+
+    void display_reg(int pe_row, int pe_col, int reg_idx){
+        PE_array_2d[pe_row][pe_col].display_reg_as_fp32(reg_idx);
+    }
+private:
+    std::array<std::array<PE, _num_col>, _num_col> PE_array_2d;
+    std::shared_ptr<SPM> spm;
+};
+#endif

--- a/main.cc
+++ b/main.cc
@@ -1,8 +1,10 @@
 #include <algorithm>
 
 #include "include/common.h"
-#include "include/PE.h"
-#include "include/SPM.h"
+// #include "include/PE.h"
+// #include "include/SPM.h"
+
+#include "PEArray.h"
 
 int main() {
   // Front-end: Define a dataflow graph
@@ -16,24 +18,31 @@ int main() {
 
   code_block_0->connect_to(code_block_1);
 
-  // A local scheduler is affined to a PE, and it holds a sub-DFG
-  std::unique_ptr<LocalScheduler> scheduler = std::make_unique<LocalScheduler>();
-  scheduler->addCodeBlock(code_block_0);
-  scheduler->addCodeBlock(code_block_1);
+  // Back-end: PE excuting the dataflow graph
 
-  // Back-end: PE excuting the dataflow graph 
-  std::shared_ptr<SPM> spm = std::make_shared<SPM>();
-  PE pe(std::move(scheduler), spm);
+  PEArray<4, 4, 6*1024*1024> pe_array;
+  pe_array.add_CodeBlock(0, 0, code_block_0);
+  pe_array.add_CodeBlock(0, 1, code_block_1);
 
-  int cycles = 100;
+  int cycles = 2;
   for (int i = 0; i < cycles; i++) {
-    pe.execute_cycle();
-  }
+      // update the constraints of each code block
+      code_block_0->update_constraint();
+      code_block_1->update_constraint();
 
-  pe.display_reg_as_fp32(0);
-  pe.display_reg_as_fp32(1);
-  pe.display_reg_as_fp32(2);
-  pe.display_reg_as_fp32(3);
-  pe.display_reg_as_fp32(4);
+      // PE performs execution at the cycle,
+      pe_array.execute_cycle();
+
+      // show result
+      std::cout << "After cycle " << i << " :\n";
+      pe_array.display_reg(0, 0, 2);
+      pe_array.display_reg(0, 1, 4);
+      std::cout << std::endl;
+  }
+  // pe.display_reg_as_fp32(0);
+  // pe.display_reg_as_fp32(1);
+  // pe.display_reg_as_fp32(2);
+  // pe.display_reg_as_fp32(3);
+  // pe.display_reg_as_fp32(4);
   return 0;
 }


### PR DESCRIPTION
1. Wrap scheduler in PE. Scheduler is not seen outside of PE.
2. Wrap PE in PEArray, which can be manipulated in main.cc
3. Update the constraint of CodeBlock synchronized 